### PR TITLE
Pin redis to prevent invalid input error

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -33,3 +33,4 @@ django-dynamic-preferences==0.8.1
 ecdsa==0.13
 django-tinymce==2.6.0
 python-magic==0.4.15
+redis==2.10.6


### PR DESCRIPTION
Error is: "DataError: Invalid input of type: 'CacheKey'. Convert to a byte, string or number first."

(Fix and workaround in this issue: https://github.com/niwinz/django-redis/issues/342)